### PR TITLE
Don't fail on snapshot mismatches while updating snapshots

### DIFF
--- a/lib/unexpected-snapshot-update.js
+++ b/lib/unexpected-snapshot-update.js
@@ -44,7 +44,6 @@ module.exports = {
             status: 'missing'
           });
           ensureAfterHookIsRegistered(topLevelFixes);
-          expect.fail();
         } else {
           throw new Error(
             'unexpected-snapshot: Could not figure out the location of the expect() call to patch up'
@@ -69,14 +68,17 @@ module.exports = {
             expect(subjectForAssertion, 'to equal', args[0]);
           },
           err => {
-            topLevelFixes.push({
-              ...expect.context[symbol],
-              subject,
-              assertionName: expect.testDescription,
-              status: 'mismatch'
-            });
-            ensureAfterHookIsRegistered(topLevelFixes);
-            throw err;
+            if (err.isUnexpected) {
+              topLevelFixes.push({
+                ...expect.context[symbol],
+                subject,
+                assertionName: expect.testDescription,
+                status: 'mismatch'
+              });
+              ensureAfterHookIsRegistered(topLevelFixes);
+            } else {
+              throw err;
+            }
           }
         );
       }


### PR DESCRIPTION
We will correct the problem for the use, so it is no longer failing from the users point of view.