### PR TITLE
Run the fixed source through prettier if available and configured

### DIFF
--- a/lib/ensureAfterHookIsRegistered.js
+++ b/lib/ensureAfterHookIsRegistered.js
@@ -10,6 +10,11 @@ const SourceCodeFixer = require('eslint/lib/linter/source-code-fixer');
 const run = require('./run');
 const Promise = require('bluebird');
 
+let prettier;
+try {
+  prettier = require('prettier');
+} catch (err) {}
+
 function stringify(obj, indentationWidth, inspect) {
   if (obj.includes('\n')) {
     return `expect.unindent\`${indentString(
@@ -289,7 +294,20 @@ function ensureAfterBlockIsRegistered(topLevelFixes) {
         fixesByFileName[fileName].map(fix => ({ fix }))
       );
       if (fixResult.fixed) {
-        fixedSourceTextByFileName[fileName] = fixResult.output;
+        let fixedSource = fixResult.output;
+        if (prettier) {
+          const prettierConfig = prettier.resolveConfig.sync(fileName);
+          if (prettierConfig) {
+            fixedSource = prettier.format(fixedSource, {
+              // Silence warning about using the default babel parser
+              // The parser is still overridable from .prettierrc, as that will come out in prettierConfig
+              parser: 'babel',
+              ...prettierConfig
+            });
+          }
+        }
+
+        fixedSourceTextByFileName[fileName] = fixedSource;
       }
     }
 

--- a/lib/ensureAfterHookIsRegistered.js
+++ b/lib/ensureAfterHookIsRegistered.js
@@ -11,9 +11,11 @@ const run = require('./run');
 const Promise = require('bluebird');
 
 let prettier;
-try {
-  prettier = require('prettier');
-} catch (err) {}
+if (!/^(?:0|false|off|no)$/.test(process.env.UNEXPECTED_SNAPSHOT_PRETTIER)) {
+  try {
+    prettier = require('prettier');
+  } catch (err) {}
+}
 
 function stringify(obj, indentationWidth, inspect) {
   if (obj.includes('\n')) {
@@ -296,15 +298,12 @@ function ensureAfterBlockIsRegistered(topLevelFixes) {
       if (fixResult.fixed) {
         let fixedSource = fixResult.output;
         if (prettier) {
-          const prettierConfig = prettier.resolveConfig.sync(fileName);
-          if (prettierConfig) {
-            fixedSource = prettier.format(fixedSource, {
-              // Silence warning about using the default babel parser
-              // The parser is still overridable from .prettierrc, as that will come out in prettierConfig
-              parser: 'babel',
-              ...prettierConfig
-            });
-          }
+          fixedSource = prettier.format(fixedSource, {
+            // Silence warning about using the default babel parser
+            // The parser is still overridable from .prettierrc, as that will come out in the resolved prettier config
+            parser: 'babel',
+            ...prettier.resolveConfig.sync(fileName)
+          });
         }
 
         fixedSourceTextByFileName[fileName] = fixedSource;

--- a/test/unexpected-snapshot.js
+++ b/test/unexpected-snapshot.js
@@ -95,20 +95,7 @@ describe('with snapshot updating on', function() {
   );
 
   expect.addAssertion(
-    '<any> with prettier enabled <assertion>',
-    async expect => {
-      const prettierRcFileName = pathModule.join(tmpDir, '.prettierrc');
-      await fs.writeFileAsync(prettierRcFileName, '{"singleQuote": true}\n');
-      try {
-        await expect.shift();
-      } finally {
-        await fs.unlinkAsync(prettierRcFileName);
-      }
-    }
-  );
-
-  expect.addAssertion(
-    '<string|function> to come out as [exactly] <string|function>',
+    '<string|function> [with prettier enabled] to come out as [exactly] <string|function>',
     async (expect, subject, value) => {
       if (!expect.flags.exactly) {
         subject = beautifyJavaScript(subject);
@@ -117,8 +104,16 @@ describe('with snapshot updating on', function() {
       const tmpFileName = await writeTestToTemporaryFile(subject);
       expect.errorMode = 'nested';
 
+      const prettier = expect.flags['with prettier enabled'];
+      let prettierRcFileName;
+      if (prettier) {
+        prettierRcFileName = pathModule.join(tmpDir, '.prettierrc');
+        await fs.writeFileAsync(prettierRcFileName, '{"singleQuote": true}\n');
+      }
+
       try {
         const [err, stdout, stderr] = await runWithMocha(tmpFileName, {
+          UNEXPECTED_SNAPSHOT_PRETTIER: prettier ? 'on' : 'off',
           UNEXPECTED_SNAPSHOT: 'on'
         });
         if (stderr) {
@@ -147,6 +142,9 @@ describe('with snapshot updating on', function() {
           expect.fail(stdout2);
         }
       } finally {
+        if (prettierRcFileName) {
+          await fs.unlinkAsync(prettierRcFileName);
+        }
         await fs.unlinkAsync(tmpFileName);
       }
     }
@@ -784,8 +782,8 @@ it('should foo', function() {
     describe('with changes due in multiple test files using different instances of the plugin', function() {
       it('should rewrite both files', async function() {
         const src = `
-          it('should foo', function() {
-            expect('foo', 'to equal snapshot');
+          it("should foo", function() {
+            expect("foo", "to equal snapshot");
           });
         `;
         const tmpFileNames = await Promise.all([
@@ -802,7 +800,7 @@ it('should foo', function() {
         expect(
           fixedSrcs,
           'to have items satisfying to contain',
-          `expect('foo', 'to equal snapshot', 'foo');`
+          `expect("foo", "to equal snapshot", "foo");`
         );
       });
     });


### PR DESCRIPTION
I can't count the number of times I've broken the build because I forgot to run `prettier --write` after updating snapshots. Seems easy and low risk to detect that the project uses prettier and use the programmatic interface to reformat the files before writing.