### PR TITLE
Make sure we write out all fixed files, even when multiple plugin instances are in play

### DIFF
--- a/lib/unexpected-snapshot-update.js
+++ b/lib/unexpected-snapshot-update.js
@@ -23,19 +23,20 @@ function extractCallerLocationFromStack(stack) {
   }
 }
 
+// Make sure that these are the same instances even if the plugin is installed into different expects
+// in different files:
+const symbol = Symbol('unexpectedSnapshot');
+const topLevelFixes = [];
+
 module.exports = {
   name: 'unexpected-snapshot',
   version: require('../package.json').version,
   installInto(expect) {
     const inspect = createInspector(expect);
 
-    const symbol = Symbol('unexpectedSnapshot');
-
-    const topLevelFixes = [];
-
     expect.addAssertion(
       ['<any> to equal snapshot', '<any> to inspect as snapshot'],
-      (expect, subject, ...args) => {
+      (expect, subject) => {
         if (expect.context[symbol]) {
           topLevelFixes.push({
             ...expect.context[symbol],
@@ -43,6 +44,7 @@ module.exports = {
             assertionName: expect.testDescription,
             status: 'missing'
           });
+
           ensureAfterHookIsRegistered(topLevelFixes);
         } else {
           throw new Error(


### PR DESCRIPTION
I had to run `UNEXPECTED_SNAPSHOT=1 npm test` multiple times to get all snapshots updated in html-generators and css-generators. Turns out there was a good reason for that :cat: