### PR TITLE
Inspect as a string literal instead of expect.unindent when a multiline string has leading spaces

### DIFF
--- a/lib/applyFixes.js
+++ b/lib/applyFixes.js
@@ -7,7 +7,7 @@ const indentString = require('./indentString');
 const maybeApplyPrettier = require('./maybeApplyPrettier');
 
 function stringify(obj, indentationWidth, inspect) {
-  if (obj.includes('\n')) {
+  if (obj.includes('\n') && !/^\n*[ \t]/.test(obj)) {
     return `expect.unindent\`${indentString(
       obj.replace(/`/g, '\\`'),
       indentationWidth

--- a/test/unexpected-snapshot.js
+++ b/test/unexpected-snapshot.js
@@ -286,6 +286,38 @@ it('should foo', function() {
       );
     });
 
+    it('should opt out of the expect.unindent mode when a multiline string starts with newlines followed by space', function() {
+      return expect(
+        `
+it('should foo', function() {
+  expect('\\n foo', 'to equal snapshot');
+});
+      `,
+        'to come out as exactly',
+        `
+it('should foo', function() {
+  expect('\\n foo', 'to equal snapshot', '\\n foo');
+});
+      `
+      );
+    });
+
+    it('should opt out of the expect.unindent mode when a multiline string starts with space', function() {
+      return expect(
+        `
+it('should foo', function() {
+  expect(' foo\\n', 'to equal snapshot');
+});
+      `,
+        'to come out as exactly',
+        `
+it('should foo', function() {
+  expect(' foo\\n', 'to equal snapshot', ' foo\\n');
+});
+      `
+      );
+    });
+
     it('should base the indent on the literal being replaced', function() {
       return expect(
         `


### PR DESCRIPTION
Came up here: https://gitter.im/unexpectedjs/unexpected?at=5df10bd00995661eb8c9a2ea