### PR TITLE
Make the compact inspection of objects independent of the terminal width

### DIFF
--- a/lib/createInspector.js
+++ b/lib/createInspector.js
@@ -34,9 +34,9 @@ const createInspector = (expect) => {
     });
   }
 
-  // Make sure that the object type doesn't use the "compact" mode where multiple properties get packed according
-  // to the terminal width:
-  expectForRendering.output.preferredWidth = 0;
+  // Avoid snapshot mismatches due to the object type's inspection compact feature, which uses the terminal width.
+  // https://gitter.im/unexpectedjs/unexpected?at=5fd14facbf641c58b41f5814
+  expectForRendering.output.preferredWidth = 80;
 
   expectForRendering.addType({
     base: 'Error',

--- a/lib/createInspector.js
+++ b/lib/createInspector.js
@@ -34,6 +34,10 @@ const createInspector = (expect) => {
     });
   }
 
+  // Make sure that the object type doesn't use the "compact" mode where multiple properties get packed according
+  // to the terminal width:
+  expectForRendering.output.preferredWidth = 0;
+
   expectForRendering.addType({
     base: 'Error',
     name: 'overriddenError',

--- a/test/unexpected-snapshot.js
+++ b/test/unexpected-snapshot.js
@@ -183,13 +183,7 @@ describe('with snapshot updating on', function () {
             expect(
               ['a', 'b', 'c'],
               'to inspect as snapshot',
-              expect.unindent`
-    [
-      'a',
-      'b',
-      'c'
-    ]
-  `
+              "[ 'a', 'b', 'c' ]"
             );
           });
         }
@@ -213,13 +207,7 @@ describe('with snapshot updating on', function () {
             expect(
               ['a', 'b', 'c'],
               'to inspect as snapshot',
-              expect.unindent`
-    [
-      'a',
-      'b',
-      'c'
-    ]
-  `
+              "[ 'a', 'b', 'c' ]"
             );
           });
         }
@@ -245,13 +233,7 @@ describe('with snapshot updating on', function () {
               ['c', 'a', 'b'],
               'when sorted',
               'to inspect as snapshot',
-              expect.unindent`
-    [
-      'a',
-      'b',
-      'c'
-    ]
-  `
+              "[ 'a', 'b', 'c' ]"
             );
           });
         }
@@ -298,13 +280,7 @@ describe('with snapshot updating on', function () {
           'with unassessed to come out as',
           () => {
             it('should foo', function () {
-              assess(['a', 'b', 'c']).toInspectAsSnapshot(assess.unindent`
-    [
-      'a',
-      'b',
-      'c'
-    ]
-  `);
+              assess(['a', 'b', 'c']).toInspectAsSnapshot("[ 'a', 'b', 'c' ]");
             });
           }
         );
@@ -320,13 +296,7 @@ describe('with snapshot updating on', function () {
           'with unassessed to come out as',
           () => {
             it('should foo', function () {
-              assess(['a', 'b', 'c']).toInspectAsSnapshot(assess.unindent`
-    [
-      'a',
-      'b',
-      'c'
-    ]
-  `);
+              assess(['a', 'b', 'c']).toInspectAsSnapshot("[ 'a', 'b', 'c' ]");
             });
           }
         );
@@ -665,12 +635,7 @@ it('should foo', function() {
               expect(
                 foo,
                 'to inspect as snapshot',
-                expect.unindent`
-    {
-      bar: 123,
-      quux: [Circular]
-    }
-  `
+                '{ bar: 123, quux: [Circular] }'
               );
             });
           }
@@ -703,12 +668,7 @@ it('should foo', function() {
                 expect(
                   foo,
                   'noop to inspect as snapshot',
-                  expect.unindent`
-    {
-      bar: 123,
-      quux: [Circular]
-    }
-  `
+                  '{ bar: 123, quux: [Circular] }'
                 );
               });
             }
@@ -741,12 +701,7 @@ it('should foo', function() {
                   expect(
                     foo,
                     'noop to inspect as snapshot',
-                    expect.unindent`
-    {
-      bar: 123,
-      quux: [Circular]
-    }
-  `
+                    '{ bar: 123, quux: [Circular] }'
                   );
                 });
               }
@@ -1029,12 +984,7 @@ it('should foo', function () {
             it('should foo', function () {
               const foo = { bar: 123 };
               foo.quux = foo;
-              assess(foo).toInspectAsSnapshot(assess.unindent`
-    {
-      bar: 123,
-      quux: [Circular]
-    }
-  `);
+              assess(foo).toInspectAsSnapshot('{ bar: 123, quux: [Circular] }');
             });
           }
         );

--- a/test/unexpected-snapshot.js
+++ b/test/unexpected-snapshot.js
@@ -183,7 +183,13 @@ describe('with snapshot updating on', function () {
             expect(
               ['a', 'b', 'c'],
               'to inspect as snapshot',
-              "[ 'a', 'b', 'c' ]"
+              expect.unindent`
+    [
+      'a',
+      'b',
+      'c'
+    ]
+  `
             );
           });
         }
@@ -207,7 +213,13 @@ describe('with snapshot updating on', function () {
             expect(
               ['a', 'b', 'c'],
               'to inspect as snapshot',
-              "[ 'a', 'b', 'c' ]"
+              expect.unindent`
+    [
+      'a',
+      'b',
+      'c'
+    ]
+  `
             );
           });
         }
@@ -233,7 +245,13 @@ describe('with snapshot updating on', function () {
               ['c', 'a', 'b'],
               'when sorted',
               'to inspect as snapshot',
-              "[ 'a', 'b', 'c' ]"
+              expect.unindent`
+    [
+      'a',
+      'b',
+      'c'
+    ]
+  `
             );
           });
         }
@@ -280,7 +298,13 @@ describe('with snapshot updating on', function () {
           'with unassessed to come out as',
           () => {
             it('should foo', function () {
-              assess(['a', 'b', 'c']).toInspectAsSnapshot("[ 'a', 'b', 'c' ]");
+              assess(['a', 'b', 'c']).toInspectAsSnapshot(assess.unindent`
+    [
+      'a',
+      'b',
+      'c'
+    ]
+  `);
             });
           }
         );
@@ -296,7 +320,13 @@ describe('with snapshot updating on', function () {
           'with unassessed to come out as',
           () => {
             it('should foo', function () {
-              assess(['a', 'b', 'c']).toInspectAsSnapshot("[ 'a', 'b', 'c' ]");
+              assess(['a', 'b', 'c']).toInspectAsSnapshot(assess.unindent`
+    [
+      'a',
+      'b',
+      'c'
+    ]
+  `);
             });
           }
         );
@@ -635,7 +665,12 @@ it('should foo', function() {
               expect(
                 foo,
                 'to inspect as snapshot',
-                '{ bar: 123, quux: [Circular] }'
+                expect.unindent`
+    {
+      bar: 123,
+      quux: [Circular]
+    }
+  `
               );
             });
           }
@@ -668,7 +703,12 @@ it('should foo', function() {
                 expect(
                   foo,
                   'noop to inspect as snapshot',
-                  '{ bar: 123, quux: [Circular] }'
+                  expect.unindent`
+    {
+      bar: 123,
+      quux: [Circular]
+    }
+  `
                 );
               });
             }
@@ -701,7 +741,12 @@ it('should foo', function() {
                   expect(
                     foo,
                     'noop to inspect as snapshot',
-                    '{ bar: 123, quux: [Circular] }'
+                    expect.unindent`
+    {
+      bar: 123,
+      quux: [Circular]
+    }
+  `
                   );
                 });
               }
@@ -984,7 +1029,12 @@ it('should foo', function () {
             it('should foo', function () {
               const foo = { bar: 123 };
               foo.quux = foo;
-              assess(foo).toInspectAsSnapshot('{ bar: 123, quux: [Circular] }');
+              assess(foo).toInspectAsSnapshot(assess.unindent`
+    {
+      bar: 123,
+      quux: [Circular]
+    }
+  `);
             });
           }
         );


### PR DESCRIPTION
Context: https://gitter.im/unexpectedjs/unexpected?at=5fd14facbf641c58b41f5814